### PR TITLE
Fix search handler by exposing OrgChart globally

### DIFF
--- a/graph-api.js
+++ b/graph-api.js
@@ -756,5 +756,8 @@ const GraphAPI = (function() {
       document.getElementById('statsSection').style.display = 'block';
       document.getElementById('statsContent').innerHTML = statsHtml;
     }
-  };
+  }; 
 })();
+
+// Expose GraphAPI to global scope for inline event handlers
+window.GraphAPI = GraphAPI;

--- a/visualization.js
+++ b/visualization.js
@@ -656,3 +656,6 @@ const OrgChart = (function() {
     }
   };
 })();
+
+// Expose OrgChart to global scope for inline event handlers
+window.OrgChart = OrgChart;


### PR DESCRIPTION
## Summary
- expose OrgChart module on `window` so inline handlers like search work
- expose GraphAPI module similarly for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b783932cc88328aafa919e93caeb8a