### PR TITLE
Add clear search filter button

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,13 +200,16 @@
         
         <!-- Bottom Controls -->
         <div class="bottom-controls" id="bottomControls" style="display: none;">
-          <input type="text" id="searchInput" placeholder="Search name or title" 
+          <input type="text" id="searchInput" placeholder="Search name or title"
                  onkeydown="if(event.key==='Enter') OrgChart.searchByNameTitle()" style="max-width: 180px;">
           <button class="icon-btn" onclick="OrgChart.searchByNameTitle()" title="Search">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="11" cy="11" r="8"></circle>
               <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
             </svg>
+          </button>
+          <button class="icon-btn" onclick="OrgChart.clearHighlight()" title="Clear Search" id="clearSearchBtn" style="display: none;">
+            ✕
           </button>
           <button class="icon-btn" onclick="OrgChart.expandAll()" title="Expand All">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/styles.css
+++ b/styles.css
@@ -673,6 +673,18 @@ input[type="checkbox"] {
   border-color: var(--danger);
 }
 
+#clearSearchBtn {
+  background: rgba(231, 76, 60, 0.1);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+#clearSearchBtn:hover {
+  background: var(--danger);
+  color: white;
+  border-color: var(--danger);
+}
+
 /* D3 Styles */
 .node {
   cursor: pointer;

--- a/visualization.js
+++ b/visualization.js
@@ -408,6 +408,8 @@ const OrgChart = (function() {
         highlightedNodes = highlightedNodes.size > 0 ? highlightedNodes : null;
         const input = document.getElementById('searchInput');
         if (input) input.value = '';
+        const searchClearBtn = document.getElementById('clearSearchBtn');
+        if (searchClearBtn) searchClearBtn.style.display = 'none';
 
         // Update active class on rows
         document.querySelectorAll('.dept-row').forEach(row => {
@@ -453,10 +455,14 @@ const OrgChart = (function() {
       // Remove active class from department rows
       document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
 
-      // Show clear highlight button if we found matches
-      const clearBtn = document.getElementById('clearHighlightBtn');
-      if (clearBtn) {
-        clearBtn.style.display = highlightedNodes.size > 0 ? 'flex' : 'none';
+      // Show clear search button if we found matches
+      const clearHighlightBtn = document.getElementById('clearHighlightBtn');
+      if (clearHighlightBtn) {
+        clearHighlightBtn.style.display = 'none';
+      }
+      const clearSearchBtn = document.getElementById('clearSearchBtn');
+      if (clearSearchBtn) {
+        clearSearchBtn.style.display = highlightedNodes && highlightedNodes.size > 0 ? 'flex' : 'none';
       }
 
       if (root) {
@@ -478,10 +484,14 @@ const OrgChart = (function() {
       const input = document.getElementById('searchInput');
       if (input) input.value = '';
 
-      // Hide clear highlight button
-      const clearBtn = document.getElementById('clearHighlightBtn');
-      if (clearBtn) {
-        clearBtn.style.display = 'none';
+      // Hide clear buttons
+      const clearHighlightBtn = document.getElementById('clearHighlightBtn');
+      if (clearHighlightBtn) {
+        clearHighlightBtn.style.display = 'none';
+      }
+      const clearSearchBtn = document.getElementById('clearSearchBtn');
+      if (clearSearchBtn) {
+        clearSearchBtn.style.display = 'none';
       }
 
       // Update the visualization


### PR DESCRIPTION
## Summary
- add red X button beside search to clear name/title filter
- style clear search control and hook it into visualization logic

## Testing
- `npm test` *(fails: enoent package.json)*


------
https://chatgpt.com/codex/tasks/task_b_68b787667b848328a540a5458e5ffeab