### PR TITLE
Remove stray clear highlight button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,4 @@
-<button class="icon-btn" onclick="OrgChart.clearHighlight()" title="Clear Highlight" id="clearHighlightBtn" style="display: none;">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="12" cy="12" r="10"></circle>
-              <line x1="15" y1="9" x2="9" y2="15"></line>
-              <line x1="9" y1="9" x2="15" y2="15"></line>
-            </svg>
-          </button><!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
## Summary
- remove duplicate `clearHighlightBtn` at top of `index.html` so selecting departments no longer shows a red X in the corner

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7899bb2548328a8100ba2fd27d8da