### PR TITLE
Set ChatGPT license as default color option

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                 <label>Color By:</label>
                 <select id="colorBy" onchange="OrgChart.updateVisualization()">
                   <option value="department">Department</option>
-                  <option value="license">ChatGPT License</option>
+                  <option value="license" selected>ChatGPT License</option>
                   <option value="level">Hierarchy Level</option>
                 </select>
               </div>


### PR DESCRIPTION
## Summary
- Make "ChatGPT License" the default selection in Color By dropdown

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b78ae1639483288876934fb17d1aec