### PR TITLE
feat: add CSV export for filtered graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,13 @@
               <line x1="10" y1="14" x2="21" y2="3"></line>
             </svg>
           </button>
+          <button class="icon-btn" onclick="OrgChart.downloadCSV()" title="Download CSV">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="7 10 12 15 17 10"></polyline>
+              <line x1="12" y1="15" x2="12" y2="3"></line>
+            </svg>
+          </button>
           <button class="icon-btn" onclick="OrgChart.clearHighlight()" title="Clear Highlight" id="clearHighlightBtn" style="display: none;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="10"></circle>


### PR DESCRIPTION
## Summary
- add a download button to export the current org chart to CSV
- export includes name, title, department, location, email, license, and AI usage
- search results restrict the export when active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b99f2a50b08328828e5885a6742036