### PR TITLE
Add licensed user isolation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,6 +246,9 @@
               <line x1="12" y1="15" x2="12" y2="3"></line>
             </svg>
           </button>
+          <button class="icon-btn" onclick="OrgChart.toggleLicenseHighlight()" title="Toggle Licensed Users" id="licenseToggleBtn">
+            🔑
+          </button>
           <button class="icon-btn" onclick="OrgChart.clearHighlight()" title="Clear Highlight" id="clearHighlightBtn" style="display: none;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="10"></circle>

--- a/styles.css
+++ b/styles.css
@@ -661,6 +661,12 @@ input[type="checkbox"] {
   height: 20px;
 }
 
+#licenseToggleBtn.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+}
+
 #clearHighlightBtn {
   background: rgba(231, 76, 60, 0.1);
   border-color: var(--danger);

--- a/visualization.js
+++ b/visualization.js
@@ -13,6 +13,7 @@ const OrgChart = (function() {
   let licensedEmails = new Set();
   let highlightedDepartment = null;
   let highlightedNodes = null;
+  let licenseHighlightActive = false;
   
   // Configuration
   const config = {
@@ -69,11 +70,14 @@ const OrgChart = (function() {
       // Reset any existing search or department highlights
       highlightedDepartment = null;
       highlightedNodes = null;
+      licenseHighlightActive = false;
       document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
       const searchInput = document.getElementById('searchInput');
       if (searchInput) searchInput.value = '';
       const clearBtn = document.getElementById('clearHighlightBtn');
       if (clearBtn) clearBtn.style.display = 'none';
+      const licenseBtn = document.getElementById('licenseToggleBtn');
+      if (licenseBtn) licenseBtn.classList.remove('active');
 
       orgData = userData;
       licensedEmails = licenses;
@@ -469,6 +473,9 @@ const OrgChart = (function() {
         if (input) input.value = '';
         const searchClearBtn = document.getElementById('clearSearchBtn');
         if (searchClearBtn) searchClearBtn.style.display = 'none';
+        licenseHighlightActive = false;
+        const licenseBtn = document.getElementById('licenseToggleBtn');
+        if (licenseBtn) licenseBtn.classList.remove('active');
 
         // Update active class on rows
         document.querySelectorAll('.dept-row').forEach(row => {
@@ -489,6 +496,28 @@ const OrgChart = (function() {
       // Update the visualization
       if (root) {
         this.update(root);
+      }
+    },
+
+    // Toggle highlight of licensed users
+    toggleLicenseHighlight: function() {
+      if (licenseHighlightActive) {
+        this.clearHighlight();
+      } else {
+        highlightedDepartment = null;
+        highlightedNodes = new Set(orgData.filter(u => u.hasLicense).map(u => u.email));
+        highlightedNodes = highlightedNodes.size > 0 ? highlightedNodes : null;
+        licenseHighlightActive = true;
+        document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
+        const input = document.getElementById('searchInput');
+        if (input) input.value = '';
+        const clearBtn = document.getElementById('clearHighlightBtn');
+        if (clearBtn) clearBtn.style.display = 'flex';
+        const searchClearBtn = document.getElementById('clearSearchBtn');
+        if (searchClearBtn) searchClearBtn.style.display = 'none';
+        const licenseBtn = document.getElementById('licenseToggleBtn');
+        if (licenseBtn) licenseBtn.classList.add('active');
+        if (root) this.update(root);
       }
     },
 
@@ -516,6 +545,9 @@ const OrgChart = (function() {
       }).map(u => u.email));
 
       highlightedNodes = highlightedNodes.size > 0 ? highlightedNodes : null;
+      licenseHighlightActive = false;
+      const licenseBtn = document.getElementById('licenseToggleBtn');
+      if (licenseBtn) licenseBtn.classList.remove('active');
 
       // Remove active class from department rows
       document.querySelectorAll('.dept-row').forEach(row => row.classList.remove('active'));
@@ -539,6 +571,7 @@ const OrgChart = (function() {
     clearHighlight: function() {
       highlightedDepartment = null;
       highlightedNodes = null;
+      licenseHighlightActive = false;
 
       // Remove active class from all rows
       document.querySelectorAll('.dept-row').forEach(row => {
@@ -558,6 +591,8 @@ const OrgChart = (function() {
       if (clearSearchBtn) {
         clearSearchBtn.style.display = 'none';
       }
+      const licenseBtn = document.getElementById('licenseToggleBtn');
+      if (licenseBtn) licenseBtn.classList.remove('active');
 
       // Update the visualization
       if (root) {


### PR DESCRIPTION
## Summary
- Add key button in bottom controls to highlight only licensed users
- Style toggle with active state
- Implement logic to filter and reset licensed-user view

## Testing
- `node --check visualization.js`
- `node --check graph-api.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9aba7928c8328a149bcb5801bfea3