### PR TITLE
Replace max depth stat with isolated user count

### DIFF
--- a/visualization.js
+++ b/visualization.js
@@ -304,6 +304,9 @@ const OrgChart = (function() {
         d.x0 = d.x;
         d.y0 = d.y;
       });
+
+      // Refresh statistics to reflect current view
+      this.updateStatsPanel();
     },
     
     // Creates a curved (diagonal) path from parent to child nodes
@@ -773,8 +776,11 @@ const OrgChart = (function() {
       const stats = document.getElementById('statsPanel');
       const licensed = orgData.filter(u => u.hasLicense).length;
       const departments = [...new Set(orgData.map(u => u.department))].length;
-      const maxDepth = root ? d3.max(root.descendants(), d => d.depth) : 0;
-      
+      const visibleNodes = root ? root.descendants() : [];
+      const isolatedCount = highlightedNodes
+        ? visibleNodes.filter(d => highlightedNodes.has(d.data.email)).length
+        : 0;
+
       stats.innerHTML = `
         <div class="stat-item">
           <span class="stat-label">Total Users:</span>
@@ -789,8 +795,8 @@ const OrgChart = (function() {
           <span class="stat-value">${departments}</span>
         </div>
         <div class="stat-item">
-          <span class="stat-label">Max Depth:</span>
-          <span class="stat-value">${maxDepth}</span>
+          <span class="stat-label">Isolated Users:</span>
+          <span class="stat-value">${isolatedCount}</span>
         </div>
       `;
     }


### PR DESCRIPTION
## Summary
- Replace Max Depth statistic with count of isolated users based on currently visible highlighted nodes.
- Refresh stats panel after each tree update to keep isolated user count accurate.

## Testing
- ⚠️ `node --check visualization.js` *(command not found)*
- ⚠️ `apt-get update` *(403 Forbidden when attempting to install Node.js)*

------
https://chatgpt.com/codex/tasks/task_b_68b9b2b7ffac8328951b829be8c9ec3e