### PR TITLE
Force tcco.com email domain for org fetch

### DIFF
--- a/graph-api.js
+++ b/graph-api.js
@@ -18,6 +18,7 @@ const GraphAPI = (function() {
   
   // API configuration
   const graphBaseUrl = 'https://graph.microsoft.com/v1.0';
+  const orgDomain = 'tcco.com';
   
   // Public API
   return {
@@ -341,7 +342,15 @@ const GraphAPI = (function() {
         this.showError('fetchStatus', 'Please enter a starting user email address');
         return;
       }
-      
+
+      // Force email to use company domain
+      const username = startingEmail.split('@')[0].toLowerCase();
+      startingEmail = `${username}@${orgDomain}`;
+      const emailInput = document.getElementById('startingEmail');
+      if (emailInput) {
+        emailInput.value = startingEmail;
+      }
+
       // Reset data
       orgData = [];
       hierarchyData = null;


### PR DESCRIPTION
## Summary
- Force lookup emails to use the tcco.com domain
- Replace the starting email domain in the UI and API requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bb4a66cdf883289720f2c9e33d8e0b