### PR TITLE
Add collapse one level control

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,11 @@
                 <line x1="8" y1="12" x2="16" y2="12"></line>
               </svg>
             </button>
+            <button class="icon-btn" onclick="OrgChart.collapseOneLevel()" title="Collapse One Level">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="8" y1="12" x2="16" y2="12"></line>
+              </svg>
+            </button>
             <button class="icon-btn" onclick="OrgChart.expandAll()" title="Expand All">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="10"></circle>

--- a/visualization.js
+++ b/visualization.js
@@ -396,6 +396,42 @@ const OrgChart = (function() {
       }
     },
 
+    // Collapse the deepest expanded tier
+    collapseOneLevel: function() {
+      if (!root) return;
+
+      const nodes = root.descendants();
+      let deepestWithChildren = -1;
+
+      nodes.forEach((node) => {
+        if (node.children && node.children.length > 0) {
+          deepestWithChildren = Math.max(deepestWithChildren, node.depth);
+        }
+      });
+
+      if (deepestWithChildren < 0) return;
+
+      let collapsed = false;
+      nodes.forEach((node) => {
+        if (node.depth === deepestWithChildren && node.children && node.children.length > 0) {
+          this.collapse(node);
+          collapsed = true;
+        }
+      });
+
+      if (!collapsed) return;
+
+      let newDeepest = -1;
+      root.descendants().forEach((node) => {
+        if (node.children && node.children.length > 0) {
+          newDeepest = Math.max(newDeepest, node.depth);
+        }
+      });
+
+      currentExpandLevel = Math.max(0, newDeepest + 1);
+      this.update(root);
+    },
+
     // Expand all nodes
     expandAll: function() {
       if (!root) return;


### PR DESCRIPTION
## Summary
- add a collapse one level button beside the existing expand control
- implement logic to collapse the deepest expanded tier and keep tracking state in sync

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68c8997a943883289e0c032f4f720ff6