### PR TITLE
Add isolated licensed user statistics

### DIFF
--- a/visualization.js
+++ b/visualization.js
@@ -915,8 +915,13 @@ const OrgChart = (function() {
       const visibleLicensedPercent = visibleNodes.length > 0
         ? Math.round((visibleLicensed / visibleNodes.length) * 100)
         : 0;
-      const isolatedCount = highlightedNodes
-        ? visibleNodes.filter(d => highlightedNodes.has(d.data.email)).length
+      const highlightedVisibleNodes = highlightedNodes
+        ? visibleNodes.filter(d => highlightedNodes.has(d.data.email))
+        : [];
+      const isolatedCount = highlightedVisibleNodes.length;
+      const isolatedLicensed = highlightedVisibleNodes.filter(d => d.data.hasLicense).length;
+      const isolatedLicensedPercent = isolatedCount > 0
+        ? Math.round((isolatedLicensed / isolatedCount) * 100)
         : 0;
 
       stats.innerHTML = `
@@ -935,6 +940,10 @@ const OrgChart = (function() {
         <div class="stat-item">
           <span class="stat-label">Isolated Users:</span>
           <span class="stat-value">${isolatedCount}</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-label">Isolated Licensed Users:</span>
+          <span class="stat-value">${isolatedLicensed} (${isolatedLicensedPercent}%)</span>
         </div>
         <div class="stat-item">
           <span class="stat-label">Visible Users:</span>


### PR DESCRIPTION
## Summary
- calculate isolated licensed counts and percentages alongside existing statistics
- show isolated licensed users in the stats panel template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c8a3ea3df483288d045c1a4e959a75